### PR TITLE
Allow Sweet Retreat to reach level 35

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -56,6 +56,7 @@ export const LIMIT = {
   adventurer_4: 70,
   adventurer_5: 80,
   altar: 35,
+  eventE: 35,
   augments: 100,
   dojo: 35,
   dracolith: 20,

--- a/src/data/halidom.js
+++ b/src/data/halidom.js
@@ -15,7 +15,7 @@ const halidom = {
   adventurer_Light_altar_0: { id: '100404', type: 'altar', level: 35 },
   adventurer_Light_altar_1: { id: '100404', type: 'altar', level: 35 },
   adventurer_Light_eventE_0: { id: '100901', type: 'eventE', level: 30 },
-  adventurer_Light_eventE_1: { id: '101501', type: 'eventE', level: 30 },
+  adventurer_Light_eventE_1: { id: '101501', type: 'eventE', level: 35 },
   adventurer_Light_slime_0: { id: '101904', type: 'slime', level: 15 },
   adventurer_Shadow_altar_0: { id: '100405', type: 'altar', level: 35 },
   adventurer_Shadow_altar_1: { id: '100405', type: 'altar', level: 35 },
@@ -168,6 +168,11 @@ export const HALIDOM_VALUES = {
     [8, 6.5],
     [8, 7],
     [8.5, 7],
+    [8.5, 7.5],
+    [9, 7.5],
+    [9, 8],
+    [9.5, 8],
+    [9.5, 8.5]
   ],
   eventW: [
     [0, 0],


### PR DESCRIPTION
Hello! I wasn't sure if you allowed outside PRs or not, but thought this would be a quick one so I figured why not try :)

This sets up the Sweet Retreat to default to level 35 and adds the stat values for the elemental event facilities for levels 31 - 35.

However, this sets the limit for all elemental event facilities to be 35, but only Sweet Retreat defaults to level 35. I wasn't sure if it was worth adding extra logic around this facility specifically going to 35 when I imagine we will see this change go into effect either in future reruns or when they add the ability to freely play old events. That being said, I would be happy to add that logic if you would like!

Edit: I also just wanted to say thank you for making such a valuable tool for the community!